### PR TITLE
Convert from .NET 4.6.1 to .NET Standard 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/bin
 **/obj
 **/*.user
+*.DS_Store

--- a/Graph3D.Vrml/Graph3D.Vrml.csproj
+++ b/Graph3D.Vrml/Graph3D.Vrml.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netcoreapp1.0</TargetFrameworks>
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryUrl>https://github.com/SavchukSergey/graph3D.vrml</RepositoryUrl>
     <Description>Vrml parser</Description>


### PR DESCRIPTION
This is done to enable the library to be used on Mac and Linux.

.NET Standard is supported everywhere 4.6.1 is supported so this should not be a breaking change.

Thank you for writing this library!