### PR TITLE
Fix parsing of "-1E-06"

### DIFF
--- a/Graph3D.Vrml/Tokenizer/NumberState.cs
+++ b/Graph3D.Vrml/Tokenizer/NumberState.cs
@@ -60,6 +60,9 @@ namespace Graph3D.Vrml.Tokenizer {
                     } else if (tokenizer.IsWhiteSpace(ch) || tokenizer.IsPunctuation(ch)) {
                         context.Enqueue(new VRML97Token(text, VRML97TokenType.Word));
                         return new InitialState(context);
+                    } else if (ch == 'e' || ch == 'E') {
+                        text += context.ReadChar();
+                        state = "sndne";
                     } else {
                         throw new TokenizerException("Invalid Number");
                     }


### PR DESCRIPTION
Not sure if this library is maintained, but I found this bug while working on a one-off VRML fix script. Thought I might as well send a PR. Seems to work but I didn't try very hard to test it properly.