### PR TITLE
Add net8.0 to target frameworks

### DIFF
--- a/Graph3D.Vrml/Graph3D.Vrml.csproj
+++ b/Graph3D.Vrml/Graph3D.Vrml.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netcoreapp1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netcoreapp1.0;net8.0</TargetFrameworks>
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryUrl>https://github.com/SavchukSergey/graph3D.vrml</RepositoryUrl>
     <Description>Vrml parser</Description>
     <PackageTags>VRML</PackageTags>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
   </PropertyGroup>
   
 </Project>

--- a/Graph3D.Vrml/Graph3D.Vrml.csproj
+++ b/Graph3D.Vrml/Graph3D.Vrml.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.0;netcoreapp1.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.1</TargetFrameworks>
     <Copyright>Copyright © 2018</Copyright>
     <RepositoryUrl>https://github.com/SavchukSergey/graph3D.vrml</RepositoryUrl>
     <Description>Vrml parser</Description>
     <PackageTags>VRML</PackageTags>
-    <Version>2.0.3</Version>
+    <Version>3.0.0</Version>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
This library is causing problems when included in macOS builds because it has a dependency on the very old `netcoreapp1.0`.

That version of .NET had a dependency on libuv on macOS but that library is no longer maintained and doesn't contain appropriate architectures for Macs anymore (nor for iOS).

This PR adds the `net8.0` target framework which is the latest LTS version of .NET and should work for many more years into the future. I updated `netstandard` to 2.1. I removed `netcoreapp1.0` because it has vulnerabilities along with incomplete platform support.

I bumped your version to 3.0.0 because there were some API breaking changes (around Material nodes) since the 2.x versions.

Would you be willing to upload this new package to nuget?